### PR TITLE
feat: add isSingleEmoji utility function

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Guidelines for bug reports:
    reported.
 
 2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
-   latest `master` or development branch in the repository.
+   latest `main` or development branch in the repository.
 
 3. **Isolate the problem** &mdash; ideally create a reduced test
    case and a live example.
@@ -43,7 +43,7 @@ If you'd like to test and/or contribute please follow these instructions.
 
 ```bash
 # clone your fork
-git clone -b master https://github.com/$YOUR_USERNAME/twemoji.git/
+git clone -b main https://github.com/$YOUR_USERNAME/twemoji.git/
 cd twemoji
 
 # install dependencies
@@ -89,7 +89,7 @@ commits.
 1. Push your topic branch up to your fork: `git push origin my-feature-branch`
 
 2. [Open a Pull Request](http://help.github.com/send-pull-requests/) with a
-   clear title and description. One for your changes in `master` and another one for
+   clear title and description. One for your changes in `main` and another one for
    your changes in `gh-pages`.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This guarantees that you will always use the latest version of the library.
 
 If, instead, you'd like to include the latest version explicitly, you can add the following tag:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@twemoji/api@16.0.1/dist/twemoji.min.js" integrity="sha384-ffx6atwP+2a1uHhw+XT6uAGhdssJviyWfbhOgvzJqE1X+qUM1Aq3mS3WW70vSq6S" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@twemoji/api@16.0.1/dist/twemoji.min.js" integrity="sha384-hiHmJUiMIDR8N8gbpoWvXIniZXfjW1HNnV6HgdH0gRH6dllfyf7xierd5uF52qnW" crossorigin="anonymous"></script>
 ```
 
 ### Download

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This guarantees that you will always use the latest version of the library.
 
 If, instead, you'd like to include the latest version explicitly, you can add the following tag:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@twemoji/api@16.0.1/dist/twemoji.min.js" integrity="sha512-qe7QHeJKVLGNciwAMbu1S872PX5bt1RY0+0xqvN7gNQ+zd3MyRJ5n7dZowEJWYRAgTN5bAUGshD1YAmkFkyAkA==" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@twemoji/api@16.0.1/dist/twemoji.min.js" integrity="sha384-ffx6atwP+2a1uHhw+XT6uAGhdssJviyWfbhOgvzJqE1X+qUM1Aq3mS3WW70vSq6S" crossorigin="anonymous"></script>
 ```
 
 ### Download

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,7 @@ export type Twemoji = {
   parse<T extends string | HTMLElement>(node: T, options?: TwemojiOptions | ParseCallback): T extends string ? string : T;
   replace(text: string, replacer: string | ReplacerFunction): string;
   test(text: string): boolean;
+  isSingleEmoji(text: string): string | null;
   onerror(): void;
 };
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -234,7 +234,21 @@ function createTwemoji() {
            *    console.log("emoji All The Things!");
            *  }
            */
-          test: test
+          test: test,
+
+          /**
+           * Given a string, returns the same string if it contains only a single emoji, null otherwise.
+           * 
+           * @param   string  some text that might be a single emoji
+           * @return  string  the same string if it contains only a single emoji, null otherwise.
+           *
+           * @example
+           *
+           *  if (twemoji.isSingleEmoji(someContent)) {
+           *    console.log("This is a single emoji!");
+           *  }
+           */
+          isSingleEmoji: isSingleEmoji
         },
 
         // used to escape HTML special chars in attributes
@@ -566,6 +580,13 @@ function createTwemoji() {
         var result = re.test(text);
         re.lastIndex = 0;
         return result;
+      }
+
+      function isSingleEmoji(text) {
+        re.lastIndex = 0;
+        var match = re.exec(text);
+        re.lastIndex = 0;
+        return match && match[0] === text ? text : null;
       }
 
       function toCodePoint(unicodeSurrogates, sep) {

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -104,6 +104,42 @@ wru.test([{
     );
   }
 },{
+  name: 'twemoji.isSingleEmoji(str)',
+  test: function () {
+    wru.assert(
+      'single emoji returns the emoji string',
+      twemoji.isSingleEmoji('\u2764') === '\u2764'
+    );
+    wru.assert(
+      'single emoji with variant returns the emoji string',
+      twemoji.isSingleEmoji('\u2764\uFE0F') === '\u2764\uFE0F'
+    );
+    wru.assert(
+      'emoji preceded by text returns null',
+      twemoji.isSingleEmoji('hello \u2764') === null
+    );
+    wru.assert(
+      'emoji followed by text returns null',
+      twemoji.isSingleEmoji('\u2764 hello') === null
+    );
+    wru.assert(
+      'two emojis returns null',
+      twemoji.isSingleEmoji('\u2764\u{1F44D}') === null
+    );
+    wru.assert(
+      'plain text returns null',
+      twemoji.isSingleEmoji('hello') === null
+    );
+    wru.assert(
+      'empty string returns null',
+      twemoji.isSingleEmoji('') === null
+    );
+    wru.assert(
+      'text-variant emoji (\\uFE0E) returns null',
+      twemoji.isSingleEmoji('\u2764\uFE0E') === null
+    );
+  }
+},{
   name: 'DOM parsing',
   test: function () {
     var img,


### PR DESCRIPTION
Adds a new isSingleEmoji(str) utility function to the twemoji package that checks whether a given string consists of exactly one emoji.

### Changes
- Added `isSingleEmoji(str: string): string | null` to the build script  
  The function returns the input string, if the input string consists of one single emoji (and nothing else), null otherwise
- Unit tests added to test that function, for single emoji input, multi-emoji input, mixed strings, and empty strings

### Motivation
There is currently no built-in way to determine if a string is a single emoji. This utility fills that gap and can be useful for input validation, emoji pickers, and reaction systems - a common use case imo.

This is a draft, because
1. I don't really get the contribution guidelines. If I just add a function, should the gh-pages branch also be updated? (I don't think so).
2. should I run `yarn prepublish`? Because this does not seem like something **I** gotta do but more liek something someone else should do once it's merged.